### PR TITLE
Update to latest OS packages and add support for Ubuntu, Fedora, and AL 2023

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -34,9 +34,8 @@ galaxy_info:
     - name: Kali
       versions:
         - "2023"
-    # We do not have an installation package for Ubuntu.
-    # - name: Ubuntu
-    #   versions:
-    #     - focal
-    #     - jammy
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
   role_name: crowdstrike

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,10 +17,9 @@ galaxy_info:
   min_ansible_version: "2.10"
   namespace: cisagov
   platforms:
-    # We do not have an installation package for Amazon Linux 2023.
-    # - name: Amazon Linux
-    #   versions:
-    #     - "2023"
+    - name: Amazon Linux
+      versions:
+        - "2023"
     - name: Debian
       versions:
         - buster

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,11 +26,10 @@ galaxy_info:
         - buster
         - bullseye
         - bookworm
-    # We do not have an installation package for Fedora.
-    # - name: Fedora
-    #   versions:
-    #     - "37"
-    #     - "38"
+    - name: Fedora
+      versions:
+        - "37"
+        - "38"
     - name: Kali
       versions:
         - "2023"

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -73,24 +73,24 @@ platforms:
   #   privileged: yes
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-ubuntu2004-ansible:latest
-  #   name: ubuntu-20-systemd
-  #   platform: amd64
-  #   pre_build_image: yes
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-ubuntu2204-ansible:latest
-  #   name: ubuntu-22-systemd
-  #   platform: amd64
-  #   pre_build_image: yes
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    name: ubuntu-20-systemd
+    platform: amd64
+    pre_build_image: yes
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    name: ubuntu-22-systemd
+    platform: amd64
+    pre_build_image: yes
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
 scenario:
   name: default
 verifier:

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -55,24 +55,24 @@ platforms:
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-fedora37-ansible:latest
-  #   name: fedora37-systemd
-  #   platform: amd64
-  #   pre_build_image: yes
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-fedora38-ansible:latest
-  #   name: fedora38-systemd
-  #   platform: amd64
-  #   pre_build_image: yes
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora37-ansible:latest
+    name: fedora37-systemd
+    platform: amd64
+    pre_build_image: yes
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: yes
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: geerlingguy/docker-ubuntu2004-ansible:latest

--- a/molecule/default/molecule-with-systemd.yml
+++ b/molecule/default/molecule-with-systemd.yml
@@ -10,15 +10,15 @@ dependency:
 driver:
   name: docker
 platforms:
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: geerlingguy/docker-amazonlinux2023-ansible:latest
-  #   name: amazonlinux2023-systemd
-  #   platform: amd64
-  #   pre_build_image: yes
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: yes
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: geerlingguy/docker-debian10-ansible:latest

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,36 @@
+---
+- name: Grab CrowdStrike Falcon system package GPG key from S3
+  ansible.builtin.aws_s3:
+    bucket: "{{ crowdstrike_third_party_bucket_name }}"
+    object: "{{ package_gpg_key_object_name }}"
+    dest: /tmp/{{ package_gpg_key_object_name }}
+    mode: get
+  become: no
+  delegate_to: localhost
+
+- name: Copy the CrowdStrike Falcon system package GPG key
+  ansible.builtin.copy:
+    dest: /tmp/{{ package_gpg_key_object_name }}
+    mode: 0700
+    src: /tmp/{{ package_gpg_key_object_name }}
+
+- name: Import CrowdStrike Falcon system package GPG key
+  ansible.builtin.rpm_key:
+    key: /tmp/{{ package_gpg_key_object_name }}
+
+- name: Install CrowdStrike Falcon (RedHat)
+  ansible.builtin.yum:
+    name:
+      - /tmp/{{ package_object_name }}
+
+- name: Delete local copy of CrowdStrike Falcon system package GPG key
+  ansible.builtin.file:
+    path: /tmp/{{ package_gpg_key_object_name }}
+    state: absent
+  become: no
+  delegate_to: localhost
+
+- name: Delete remote copy of CrowdStrike Falcon system package GPG key
+  ansible.builtin.file:
+    path: /tmp/{{ package_gpg_key_object_name }}
+    state: absent

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,36 +1,76 @@
 ---
-- name: Grab CrowdStrike Falcon system package GPG key from S3
-  ansible.builtin.aws_s3:
-    bucket: "{{ crowdstrike_third_party_bucket_name }}"
-    dest: /tmp/{{ package_gpg_key_object_name }}
-    mode: get
-    object: "{{ package_gpg_key_object_name }}"
-  become: no
-  delegate_to: localhost
+# The GPG signing key we have for the RPM cannot be imported on Amazon
+# 2023.  I get the following error output:
+#   gpg: directory '/root/.gnupg' created
+#   gpg: keybox '/root/.gnupg/pubring.kbx' created
+#   gpg: WARNING: no command supplied.  Trying to guess what you mean ...
+#   gpg: no valid OpenPGP data found.
+#   gpg: processing message failed: Unknown system error
+#
+# The GPG signing key we have for the RPM cannot be imported on Fedora
+# 38.  I get the following error:
+#   error: Certificate 4727BBD5519B177F:
+#     The certificate is expired: The primary key is not live
+#   error: /tmp/Falcon Linux Sensor RPM signing GPG key: key 1 import failed.
+#
+# This is why we do not attempt to import the key on these platforms
+# and force dnf to install the corresponding package without checking
+# the GPG key.
 
-- name: Copy the CrowdStrike Falcon system package GPG key
-  ansible.builtin.copy:
-    dest: /tmp/{{ package_gpg_key_object_name }}
-    mode: 0700
-    src: /tmp/{{ package_gpg_key_object_name }}
+- name: Set a fact that denoting whether or not to import the GPG key
+  block:
+    - name: Set a fact denoting whether or not this is Amazon Linux
+      ansible.builtin.set_fact:
+        not_amazon: "{{ not ansible_distribution == 'Amazon' }}"
+    - name: Set a fact denoting whether or not this is Fedora 38
+      ansible.builtin.set_fact:
+        not_fedora_38: "{{ not (ansible_distribution == 'Fedora' and ansible_distribution_major_version == '38') }}"
+    - name: Set a fact denoting whether or not to import the GPG key
+      ansible.builtin.set_fact:
+        import_gpg_signature_key: "{{ not_amazon and not_fedora_38 }}"
 
 - name: Import CrowdStrike Falcon system package GPG key
-  ansible.builtin.rpm_key:
-    key: /tmp/{{ package_gpg_key_object_name }}
+  # See the comment block at the top of this file.
+  when: import_gpg_signature_key
+  block:
+    - name: Grab CrowdStrike Falcon system package GPG key from S3
+      ansible.builtin.aws_s3:
+        bucket: "{{ crowdstrike_third_party_bucket_name }}"
+        dest: /tmp/{{ package_gpg_key_object_name }}
+        mode: get
+        object: "{{ package_gpg_key_object_name }}"
+      become: no
+      delegate_to: localhost
+
+    - name: Copy the CrowdStrike Falcon system package GPG key
+      ansible.builtin.copy:
+        dest: /tmp/{{ package_gpg_key_object_name }}
+        mode: 0700
+        src: /tmp/{{ package_gpg_key_object_name }}
+
+    - name: Import CrowdStrike Falcon system package GPG key
+      ansible.builtin.rpm_key:
+        key: /tmp/{{ package_gpg_key_object_name }}
 
 - name: Install CrowdStrike Falcon (RedHat)
   ansible.builtin.dnf:
+    # See the comment block at the top of this file.
+    disable_gpg_check: "{{ not import_gpg_signature_key }}"
     name:
       - /tmp/{{ package_object_name }}
 
-- name: Delete local copy of CrowdStrike Falcon system package GPG key
-  ansible.builtin.file:
-    path: /tmp/{{ package_gpg_key_object_name }}
-    state: absent
-  become: no
-  delegate_to: localhost
+- name: Delete copies of CrowdStrike Falcon system package GPG key
+  # See the comment block at the top of this file.
+  when: import_gpg_signature_key
+  block:
+    - name: Delete local copy of CrowdStrike Falcon system package GPG key
+      ansible.builtin.file:
+        path: /tmp/{{ package_gpg_key_object_name }}
+        state: absent
+      become: no
+      delegate_to: localhost
 
-- name: Delete remote copy of CrowdStrike Falcon system package GPG key
-  ansible.builtin.file:
-    path: /tmp/{{ package_gpg_key_object_name }}
-    state: absent
+    - name: Delete remote copy of CrowdStrike Falcon system package GPG key
+      ansible.builtin.file:
+        path: /tmp/{{ package_gpg_key_object_name }}
+        state: absent

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,9 +2,9 @@
 - name: Grab CrowdStrike Falcon system package GPG key from S3
   ansible.builtin.aws_s3:
     bucket: "{{ crowdstrike_third_party_bucket_name }}"
-    object: "{{ package_gpg_key_object_name }}"
     dest: /tmp/{{ package_gpg_key_object_name }}
     mode: get
+    object: "{{ package_gpg_key_object_name }}"
   become: no
   delegate_to: localhost
 

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -19,7 +19,7 @@
     key: /tmp/{{ package_gpg_key_object_name }}
 
 - name: Install CrowdStrike Falcon (RedHat)
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name:
       - /tmp/{{ package_object_name }}
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,9 @@ variable "production_objects" {
   type        = list(string)
   description = "The Falcon sensor system package objects inside the production bucket."
   default = [
+    "Falcon Linux Sensor RPM signing GPG key",
     "falcon-sensor_*_amd64.deb",
+    "falcon-sensor-*.x86_64.rpm",
   ]
 }
 
@@ -34,7 +36,9 @@ variable "staging_objects" {
   type        = list(string)
   description = "The Falcon sensor system packages inside the staging bucket."
   default = [
+    "Falcon Linux Sensor RPM signing GPG key",
     "falcon-sensor_*_amd64.deb",
+    "falcon-sensor-*.x86_64.rpm",
   ]
 }
 

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,8 @@
+---
+# The name of the S3 object corresponding to the CrowdStrike Falcon
+# sensor system package
+package_object_name: falcon-sensor-6.56.0-15309.amzn2023.x86_64.rpm
+
+# The name of the S3 object corresponding to the GPG key for the
+# CrowdStrike Falcon system package
+package_gpg_key_object_name: "Falcon Linux Sensor code signing certificate 2021.pem"

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -2,7 +2,3 @@
 # The name of the S3 object corresponding to the CrowdStrike Falcon
 # sensor system package
 package_object_name: falcon-sensor-6.56.0-15309.amzn2023.x86_64.rpm
-
-# The name of the S3 object corresponding to the GPG key for the
-# CrowdStrike Falcon system package
-package_gpg_key_object_name: "Falcon Linux Sensor code signing certificate 2021.pem"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 # The name of the S3 object corresponding to the CrowdStrike Falcon
 # sensor system package
-package_object_name: falcon-sensor_6.45.0-14203_amd64.deb
+package_object_name: falcon-sensor_6.54.0-15110_amd64.deb

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,8 @@
+---
+# The name of the S3 object corresponding to the CrowdStrike Falcon
+# sensor system package
+package_object_name: falcon-sensor-6.54.0-15110.el8.x86_64.rpm
+
+# The name of the S3 object corresponding to the GPG key for the
+# CrowdStrike Falcon system package
+package_gpg_key_object_name: "Falcon Linux Sensor RPM signing GPG key"


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to:
- Use the latest versions of the OS packages
- Support Ubuntu, Fedora, and Amazon Linux 2023

## 💭 Motivation and context ##

- We may as well use the latest versions of the OS packages as opposed to relying on CDM to update them for us.  (Also our packages were woefully outdated - two major versions behind!)
- Supporting Fedora will help us to add CrowdStrike support to [our FreeIPA server AMI](https://github.com/cisagov/freeipa-server-packer).

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.